### PR TITLE
Update submitted_unaligned_reads.yaml

### DIFF
--- a/gdcdictionary/schemas/submitted_unaligned_reads.yaml
+++ b/gdcdictionary/schemas/submitted_unaligned_reads.yaml
@@ -121,7 +121,7 @@ properties:
   mycobacterium_tuberculosis_lineage:
     description: >
       Classification determined by spoligotype using the lorikeet spoligotype analysis software.
-    type: string
+    type: array
 
   read_groups:
     $ref: "_definitions.yaml#/to_one"


### PR DESCRIPTION
The values for this property is often a list separated by commas. These commas are then turned into `\t` which then causes issues when the file exported, shifting columns in tsv file exports.